### PR TITLE
add yml support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ arsenal_cli.egg-info/
 build/
 dist/
 Pipfile.lock
+Pipfile

--- a/arsenal/modules/config.py
+++ b/arsenal/modules/config.py
@@ -5,7 +5,7 @@ from os.path import dirname, abspath, expanduser, join
 DATAPATH = join(dirname(dirname(abspath(__file__))), 'data')
 BASEPATH = dirname(dirname(dirname(abspath(__file__))))
 HOMEPATH = expanduser("~")
-FORMATS = ["md", "rst"]
+FORMATS = ["md", "rst", "yml"]
 EXCLUDE_LIST = ["README.md", "README.rst", "index.rst"]
 
 CHEATS_PATHS = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 libtmux
 docutils
 pyperclip
+pyyaml


### PR DESCRIPTION
Hey! 

This pull request brings the support of cheats wrote in a yaml file. It's pretty usefull for dynamically  managing your cheats as I do with python and pyyaml for example.

Here an example file

```yml
evil_winrm:
  name: evil winrm
  description: WinRM shell for hacking / pentesting
  url: https://github.com/Hackplayers/evil-winrm
  os: linux
  install: github
  docker: 'yes'
  language: ruby
  categories: [pentest, windows]
  tags: [winrm]
  command_tags: [plateform/linux, target/remote, cat/ATTACK]
  cmds:
    simple_connect:
      name: simple connect as user
      description: connect to windows target as user with password
      categories: [pentest, windows]
      tags: [winrm]
      command_tags: [port/5985]
      cmd: evil-winrm -i <host> -u <user> -p <password>
```

Thanks for arsenal.