### PR TITLE
Fuzzing capability

### DIFF
--- a/arsenal/modules/config.py
+++ b/arsenal/modules/config.py
@@ -7,6 +7,7 @@ BASEPATH = dirname(dirname(dirname(abspath(__file__))))
 HOMEPATH = expanduser("~")
 FORMATS = ["md", "rst"]
 EXCLUDE_LIST = ["README.md", "README.rst", "index.rst"]
+FUZZING_DIRS = ["/usr/local/share/wordlists/**/*.txt"]
 
 CHEATS_PATHS = [
     join(DATAPATH, "cheats"),  # DEFAULT

--- a/arsenal/modules/gui.py
+++ b/arsenal/modules/gui.py
@@ -716,6 +716,19 @@ class ArgslistMenu:
                     # go to the next argument
                     else:
                         self.next_arg()
+            elif c == 20:
+                try:
+                    from pyfzf.pyfzf import FzfPrompt
+                    files = []
+                    for fuzz_dir in config.FUZZING_DIRS:
+                        files += glob.glob(fuzz_dir, recursive=True)
+                    fzf = FzfPrompt().prompt(files)
+                    # autocomplete the argument 
+                    Gui.cmd.args[self.current_arg][1] = fzf[0]
+                    # update cursor position
+                    self.xcursor = self.x_init + len(fzf[0])
+                except:
+                    pass
             elif c == curses.KEY_BACKSPACE or c == 127 or c == 8:
                 if self.check_move_cursor(-1):
                     i = self.xcursor - self.x_init - 1


### PR DESCRIPTION
This PR adds the power of fzf into this tool. A new config var has been added in order to specify which fuzzing directories will be used. There is no need of adding the `pyfzf` extensions to the requirements since it's added in a Pythonic way. In case the extension is not installed, arsenal will behave the same as always. If the extension is installed you will be able to fuzz specified directories in the config using `ctrl+t`.

Example of fuzzing wordlist directory:

[![asciicast](https://asciinema.org/a/LwZzi7CH7WTvGIelQl6kUzdxm.svg)](https://asciinema.org/a/LwZzi7CH7WTvGIelQl6kUzdxm)