### PR TITLE
Added AUR instalation

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,24 @@
+#Maintainer: Erick Sanchez Vera "T1erno" <erickdeveloper2000@outlook com>
+
+pkgname=arsenal
+pkgver=1.1.0
+pkgrel=1
+pkgdesc='Arsenal is just a quick inventory and launcher for hacking programs'
+url='https://github.com/Orange-Cyberdefense/arsenal'
+arch=('any')
+license=('GPL')
+depends=('python>=3.7')
+source=(${pkgname}::git+https://github.com/Orange-Cyberdefense/arsenal.git)
+sha512sums=('SKIP')
+
+build() {
+	cd $pkgname
+	python setup.py build
+}
+
+package() {
+	cd $pkgname
+	python setup.py install --prefix=/usr --root="${pkgdir}" -O1 --skip-build
+	install -Dm 644 LICENSE -t "${pkgdir}"/usr/share/licenses/${pkgname}
+	install -Dm 644 README.md -t "${pkgdir}"/usr/share/doc/${pkgname}
+}

--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ Inside your .bashrc or .zshrc add the path to `run` to help you do that you coul
 ./addalias.sh
 ```
 
+- Also if you are an Arch user you can install from the AUR:
+```bash
+git clone https://aur.archlinux.org/arsenal.git
+cd arsenal 
+makepkg -si
+```
+- Or with an AUR helper like yay:
+```bash
+yay -S arsenal
+```
+
 ## Launch in tmux mode
 
 ```


### PR DESCRIPTION
The AUR is a special repository for Arch-based distributions, in which you can share your projects and receive updates with the Arch package manager as the project is modified. This commit adds support for installation from the AUR.