### PR TITLE
Added aliases for shell configurations in PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -20,6 +20,11 @@ build() {
 
 package() {
 	cd $pkgname
+
+	echo "alias a='arsenal'" >> ~/.bash_aliases
+	echo "alias a='arsenal'" >> ~/.zshrc
+	echo "alias a='arsenal'" >> ~/.bashrc
+
 	python setup.py install --prefix=/usr --root="${pkgdir}" -O1 --skip-build
 	install -Dm 644 LICENSE -t "${pkgdir}"/usr/share/licenses/${pkgname}
 	install -Dm 644 README.md -t "${pkgdir}"/usr/share/doc/${pkgname}


### PR DESCRIPTION
As mentioned at https://github.com/Orange-Cyberdefense/arsenal/blob/master/addalias.sh, you could set 'a' as an alias in the shell configuration to run arsenal. This commit adds those aliases automatically to the shell configuration for people installing arsenal through yay on Arch Linux and derivatives.