### PR TITLE
Update README.md adding troubleshooting step for TIOCSTI error

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ pip install -U PyYAML
 
 --
 
-If you an exception similar to the following (contains TIOCSTI in strace) when running Arsenal:
+If you encounter an exception similar to the following (contains TIOCSTI in strace) when running Arsenal:
 ```
 [...]
     fcntl.ioctl(stdin, termios.TIOCSTI, c)

--- a/README.md
+++ b/README.md
@@ -118,6 +118,19 @@ If the exception is still there:
 pip install -U PyYAML
 ```
 
+--
+
+If you an exception similar to the following (contains TIOCSTI in strace) when running Arsenal:
+```
+[...]
+    fcntl.ioctl(stdin, termios.TIOCSTI, c)
+OSError: [Errno 5] Input/output error
+```
+Then you may need to re-enable TIOCSTI:
+```
+sudo sysctl -w dev.tty.legacy_tiocsti=1
+```
+
 ## Mindmap
 - Active directory mindmap
   - Due to csp on github when you open the svg, we moved the AD mindmap and the source to this repository : [https://github.com/Orange-Cyberdefense/ocd-mindmaps](https://github.com/Orange-Cyberdefense/ocd-mindmaps)


### PR DESCRIPTION
Include troubleshooting step to readme for error related to TIOCSTI being disabled by default in recent kernels.