### PR TITLE
Fix: #70 - problem with md variable parsing

### DIFF
--- a/arsenal/modules/command.py
+++ b/arsenal/modules/command.py
@@ -46,7 +46,7 @@ class Command:
         self.args = []
         # Use a list of tuples here instead of dict in case
         # the cmd has multiple args with the same name..
-        for arg_name in re.findall(r'<([^ <>:]+)>', cheat.command):
+        for arg_name in re.findall(r'<([^ <>]+)>', cheat.command):
             if "|" in arg_name:  # Format <name|default_value>
                 name, var = arg_name.split("|")[:2]
                 self.args.append([name, var])


### PR DESCRIPTION
As raised in issue #70, Arsenal was not correctly parsing cheats that contained a colon (:) within <>.
I have removed the colon that was found within the arg_name regex check in command.py, as I don't believe this is needed for command argument parsing.
I have checked it across multiple commands and have found no errors.