### PR TITLE
Add command prefix option

### DIFF
--- a/arsenal/app.py
+++ b/arsenal/app.py
@@ -48,6 +48,7 @@ class App:
         group_out.add_argument('-e', '--exec', action='store_true', help='Execute cmd')
         group_out.add_argument('-t', '--tmux', action='store_true', help='Send command to tmux panel')
         group_out.add_argument('-c', '--check', action='store_true', help='Check the existing commands')
+        group_out.add_argument('-f', '--prefix', action='store_true', help='command prefix')
         parser.add_argument('-V', '--version', action='version', version='%(prog)s (version {})'.format(__version__))
 
         return parser.parse_args()
@@ -69,7 +70,7 @@ class App:
         gui = arsenal_gui.Gui()
         while True:
             # launch gui
-            cmd = gui.run(cheatsheets)
+            cmd = gui.run(cheatsheets, args.prefix)
 
             if cmd == None:
                 exit(0)

--- a/arsenal/modules/config.py
+++ b/arsenal/modules/config.py
@@ -23,3 +23,5 @@ os.environ.setdefault('ESCDELAY', '25')
 os.environ['TERM'] = 'xterm-256color'
 
 savevarfile = join(HOMEPATH, ".arsenal.json")
+
+PREFIX_GLOBALVAR_NAME = "arsenal_prefix_cmd"

--- a/arsenal/modules/gui.py
+++ b/arsenal/modules/gui.py
@@ -809,7 +809,12 @@ class Gui:
             result_string = str_value[:max_size - 4] + '...'
         return result_string
 
-    def run(self, cheatsheets):
+    @staticmethod
+    def prefix_cmdline_with_prefix():
+        if config.PREFIX_GLOBALVAR_NAME in Gui.arsenalGlobalVars:
+            Gui.cmd.cmdline = f"{Gui.arsenalGlobalVars[config.PREFIX_GLOBALVAR_NAME]} {Gui.cmd.cmdline}"
+
+    def run(self, cheatsheets, has_prefix):
         """
         Gui entry point
         :param cheatsheets: cheatsheets dictionary
@@ -826,4 +831,6 @@ class Gui:
                 Gui.arsenalGlobalVars = json.load(f)
 
         wrapper(self.cheats_menu.run)
+        if Gui.cmd != None and Gui.cmd.cmdline[0] != '>' and has_prefix:
+            self.prefix_cmdline_with_prefix()
         return Gui.cmd


### PR DESCRIPTION
Hello here is a pull request to add an option to prefix a command generated by arsenal.

Te prefix is defined by a global var that is referenced in config.